### PR TITLE
New Feature: Sentinel-2

### DIFF
--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -244,10 +244,10 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     ::: callout-note
     **Feature Warning**
 
-    Sentinel-2 Level 2A only extends back to march 2017, since the European Space Agency (ESA) did not systematically generate Level 2A product unil then. Furthermore, the sentinel-2 atmospheric processor (Sen2cor) was release in late 2016.
+    Sentinel-2 Level 2A only extends back to march 2017, since the European Space Agency (ESA) did not systematically generate Level 2A product until then. Additionally, the 2017-2018 level 2A coverage in the earth engine collection is not yet global.
     :::
 
-2.  To address the limited coverage of Sentinel-2 in 2015-2017, Luma automatically select the Level 1C ToA reflectance data if the user select those years. Atmospheric correction of this data is not applied due to complexity of sentinel-2 pre-processing pipeline. Atmospheric correction for this data will be applied in the upcoming update.
+2.  To address the limited coverage of Sentinel-2 in 2015-2017, Luma automatically select the Level 1C ToA reflectance data if the user select those years. Atmospheric correction of this data is not applied due to complexity of sentinel-2 pre-processing pipeline. Atmospheric correction for level 1C data will be applied in the upcoming update.
 
 3.  The system retrieves images that match user’s selected criteria, including spatial resolution, target year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
 
@@ -318,7 +318,13 @@ HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MR
 ::: callout-caution
 ## Feature Note
 
-The approach as well as the procedure used to perform spatial harmonization is not shown to the user. The user only receive the harmonize imagery and note regarding the approach used
+The approach as well as the procedure used to perform spatial harmonization is not shown to the user. The user only receive the harmonize imagery and note regarding the approach used.
+:::
+
+::: callout-note
+## Feature Warning
+
+The HPF operations required significant computation time and resource for large area. Sharpening for large area (primary regency level) might hit Earth Engine's user memory limit. If this happen, set the sharpening to false `data_acquisition.final_Image.get_temporal_composite(Sharpen=False):`
 :::
 
 ## Mosaic and Composite for Satellite Imagery

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -58,14 +58,15 @@ In addition to user define upload the system supports the selection of AOI from 
 
 **Luma Geospatial Engine**
 
-1.  Load `ee.FeatureCollection` containing Indonesian administrative boundaries from Badan Informasi Geospasial. The data should be uploaded as GEE asset and the link for it must be provided and shared publicly
+1.  Load `ee.FeatureCollection` asset containing Indonesian administrative boundaries from Indonesian Geospatial Agency (*Badan Informasi Geospasial*/BIG).
 2.  The system extracts the regency name and provide complete list of the available regencies for the user
-3.  The system convert the `ee.FeatureCollection` to `geodataframe` for visualization, while using the unconverted one as an AOI for the imagery search
+3.  Extract the geometry of the selected regency boundaries and use them as criteria in the imagery filtering
+4.  Convert the `ee.FeatureCollection` to `geodataframe` and visualize in the map canvas
 
 ::: callout-tip
 ## Related Function
 
-`input_utils.load_regency_asset:` Fetching GEE asset containing Indonesia administrative boundaries
+`input_utils.load_regency_asset:` Retrieve `ee.FeatureCollection` of Indonesia regency/city level administrative boundaries from earth engine asset
 
 `input_utils.get_regency_name`: Creating a list of regency name for the user
 
@@ -228,7 +229,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     `data_acquisition.Reflectance_Data.S2_DATASETS` class-level dictionary for Sentinel-2 image collection, currently only support Level 2A Surface Reflectance collection. This dictionary has similar structure with `OPTICAL_DATASETS`
     :::
 
-    The system supports Landsat 1-3 Raw collection, Landsat 4-9 Level 2 Surface Reflectance (SR) collection, and Sentinel-2A/B Level 2A Harmonized collection. Additionally, Landsat 4 - 9 Top-of-Atmosphere (TOA) collection is used for retrieving thermal band as additional input band for the classification. Since Landsat Surface Temperature (ST) Level 2 SR data tends to result in over-correction in high contrast land cover feature, the TOA collection thermal band is used. Landsat mission availability is as follows:
+    The system currently supports Analysis Ready Data (ARD) for Landsat and Sentinel-2 satellite mission. The detailed mission and temporal coverage for each satellite data is as follows:
 
     -   Landsat 1 Multispectral Scanner/MSS (1972 - 1978)
     -   Landsat 2 Multispectral Scanner/MSS (1978 - 1982)
@@ -245,7 +246,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     ::: callout-tip
     ## Related Functions
 
-    `data_acqusition.parse_date_input():` Parse date input to YYYY-MM-DD format. Accepts either a year (int or 4-digit string) or a full date string. For year inputs, returns Jan 1 for start dates or Dec 31 for end dates. This function is used by `get_optical_data` and `get_thermal_bands`
+    `data_acqusition.parse_date_input():` Parse date input to YYYY-MM-DD format. Accepts either a year (int or 4-digit string) or a full date string. For year inputs, returns Jan 1 for start dates and Dec 31 for end dates. This function is used by `get_s2_optical_data`, `get_optical_data` and `get_thermal_bands`
 
     `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a standardize and ready to use image collection
 
@@ -254,7 +255,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     -   For Landsat imagery, cloud masking is applied using the quality assurance band (QA_PIXEL) that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
 
-    -   For Sentinel-2 imagery, Cloud masking is implemented using Cloud Score+ approach. This approach implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e).
+    -   For Sentinel-2 imagery, cloud masking is implemented using Cloud Score+ quality assessment processor. This approach use weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. This masking approach is conducted using link collection function in GEE, since Cloud Score+ collection have the same id and `system:index` properties as the individual Sentinel-2 image collection. Cloud Score+ produce more accurate cloud masking compared to other cloud masking approach such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e)
 
         ::: callout-tip
         ## Related Functions
@@ -416,7 +417,7 @@ This is a part of **System Response 1.3: Download Satellite Imagery and Continue
     `data_acquisition.Reflectance_Stats.get_collection_statistics():` to get comprehensive statistics about the gathered image collection.
     :::
 
-2.  The system provide a preset of commonly used band combinations as well as optimal value range for the imagery. The commonly used composites define in Luma-GE are:
+2.  The system provide a preset of commonly used band combinations as well as optimal value range for the imagery. The commonly used band composites define in Luma-GE are as follows:
 
     1.  True Color Composites (RED, GREEN, BLUE)
 
@@ -436,7 +437,7 @@ This is a part of **System Response 1.3: Download Satellite Imagery and Continue
     `data_acquisition.Vis_Params.get_vis_params()`: function to retrieve band combinations and visualization parameters from the define list
     :::
 
-3.  The system provide tools for the user to build their own band combinations and modified the imagery minimum/maximum value as well as the gamma value, improving the visualization of the data
+3.  The system provide tools for the user to build their own band combinations and modified the imagery minimum/maximum value as well as the gamma value.
 
     ::: callout-tip
     ## Related Function

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -186,7 +186,7 @@ This is a part of **User Journey 1.2: Determining Satellite Imageries Parameters
 
     -   Target map date: Choose the range of period of satellite imagery in a single year format (YYYY) or full-date format (YYYY-MM-DD). If YYYY is used as the input format, the year option starts from 1972 until present year. The year 2020 is shown as the default option.
 
-    -   Spatial resolution: Specify the desired spatial resolution. During Phase 1, only Landsat data will be utilized; therefore, the spatial resolution will be set on default to 30 meters.
+    -   Spatial resolution: Specify the desired spatial resolution of the final map. Three spatial resolution is supported, namely 10x10m, 30x30m, and 100x100 m. If the user select the 10x10, the user only able to select Sentinel-2 imagery only. The temporal coverage is limited from 2017-present. If the user select 30x30, the user is able to select Landsat imagery collection with the temporal coverage from 1972 - present. If the user select 100x100m the user select Landsat image collection, however the thematic details correspond to 100x100 m since this option is only available for selecting the RESTORE+ dataset
 
     -   Sensor type: a list of sensors available based on the selected target map date input parameter. Landsat 8 OLI is shown to be the default option. A warning message will show about the limited availability of Landsat 1-3 data if the user uses temporal scope input between 1972-1984.
 
@@ -196,9 +196,9 @@ This is a part of **User Journey 1.2: Determining Satellite Imageries Parameters
         An error/warning notification is shown to the user if there's no satellite data for the selected time range
         :::
 
-    -   Maximum cloud cover: Set a preferred cloud cover threshold, or use the default value of 30%.
+    -   Maximum cloud cover per-scene : Maximum scene level cloud cover for imagery filtering. Set a preferred cloud cover threshold, or use the default value of 30%.
 
-2.  The system provides information on satellite image availability shows the number of total satellite images found based on the user parameter input. The information includes total images found, date range of images, WRS tiles, path row tiles, scene IDs, image acquisition dates, average scene cloud cover, date range, and cloud cover range.
+2.  The system provides information on satellite image availability shows the number of total satellite images found based on the user parameter input. The information includes total images found, date range of images, MGRS/WRS tiles, scene IDs, image acquisition dates, average scene cloud cover, and cloud cover range.
 
     ::: callout-note
     ## Success Notification
@@ -209,24 +209,26 @@ This is a part of **User Journey 1.2: Determining Satellite Imageries Parameters
     ::: callout-important
     ## Error Handling Notification
 
-    The system provides an error notification if no satellite images were found based on the user's parameter. The user is prompted to change the cloud cover threshold or change the target map date.
+    The system provides an error notification if no satellite images were found based on the user's parameter. The user is prompted to change the cloud cover threshold, or sensor type, or change the target map date.
     :::
 
 **Luma Geospatial Engine**
 
 This is a part of **System Response 1.2: Search and Filter Imagery**
 
-1.  The system specifies Landsat data collections for optical processing.
+1.  The system fetch the predefined imagery collections for processing
 
     ::: callout-tip
     ## Related Functions
 
-    `data_acquisition.Reflectance_Data.OPTICAL_DATASETS` defines the properties of Landsat Surface Reflectance (SR) collections (Collection 2, Level-2) to be fetched for optical data processing. In this list, the metadata for reporting the data retrieval is also define. More satellite sensor can be define here
+    `data_acquisition.Reflectance_Data.OPTICAL_DATASETS` : class-level dictionary that act as a central registry for all supported Landsat collection. Each key is a user-facing dataset code, and the value contains the metadata needed to fetch and process that collection. The metadata for each entry are `collection`, `cloud_property`, `type`, `sensor`, and `description`
 
-    `data_acquisition.Reflectance_Data.THERMAL_DATASETS` Define the properties of Landsat Top-of-Atmosphere (TOA) thermal bands. Since some Landsat mission have different band names designation, the thermal band is refer in the list
+    `data_acquisition.Reflectance_Data.THERMAL_DATASETS` Similar class level dictionary for Landsat TOA collections, used for `get_thermal_bands` function. This dictionary has similar structure with `OPTICAL_DATASETS`
+
+    `data_acquisition.Reflectance_Data.S2_DATASETS` class-level dictionary for Sentinel-2 image collection, currently only support Level 2A Surface Reflectance collection. This dictionary has similar structure with `OPTICAL_DATASETS`
     :::
 
-    The system currently supports Landsat 1-3 RAW collection and and Landsat 4-9 surface reflectance (SR) collection, and Sentinel 2 Multispectral Instrument (MSI) Leve 2A Harmonized Collection. Additionally, Landsat 4 - 9 Top-of-Atmosphere (TOA) is used for retrieving thermal band as additional input band for the classification. This consideration stems from Landsat SR collection thermal band quality which often resulted in no data and prone to over-correction in high contrast land cover feature. Landsat mission availability is as follows:
+    The system supports Landsat 1-3 Raw collection, Landsat 4-9 Level 2 Surface Reflectance (SR) collection, and Sentinel-2A/B Level 2A Harmonized collection. Additionally, Landsat 4 - 9 Top-of-Atmosphere (TOA) collection is used for retrieving thermal band as additional input band for the classification. Since Landsat Surface Temperature (ST) Level 2 SR data tends to result in over-correction in high contrast land cover feature, the TOA collection thermal band is used. Landsat mission availability is as follows:
 
     -   Landsat 1 Multispectral Scanner/MSS (1972 - 1978)
     -   Landsat 2 Multispectral Scanner/MSS (1978 - 1982)
@@ -238,21 +240,21 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     -   Landsat 9 Operational Land Imager-2/OLI-2 (2021 - present)
     -   Sentinel 2A/B Multispectral Instrument/MSI (2015 - present)
 
-2.  The system retrieves images that match user’s selected criteria, including spatial resolution, year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
+2.  The system retrieves images that match user’s selected criteria, including spatial resolution, target year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
 
     ::: callout-tip
     ## Related Functions
 
     `data_acqusition.parse_date_input():` Parse date input to YYYY-MM-DD format. Accepts either a year (int or 4-digit string) or a full date string. For year inputs, returns Jan 1 for start dates or Dec 31 for end dates. This function is used by `get_optical_data` and `get_thermal_bands`
 
-    `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a masked, scaled, and renamed image collection.
+    `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a standardize and ready to use image collection
 
     `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the `mask_s2_clouds`, `apply_s2_scale_factors`, and `rename_s2_bands` to return a standardize and ready to use image collection
     :::
 
-    -   The system performs cloud masking using the quality assurance band (QA_PIXEL) QA_PIXEL band that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
+    -   For Landsat imagery, cloud masking is applied using the quality assurance band (QA_PIXEL) that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
 
-    -   Cloud masking for Sentinel-2 data use Cloud Score+ methods which implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e).
+    -   For Sentinel-2 imagery, Cloud masking is implemented using Cloud Score+ approach. This approach implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e).
 
         ::: callout-tip
         ## Related Functions
@@ -262,7 +264,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
         `data_acquisition.Reflectance_Data.mask_s2_clouds()`: Mask cloudy, hazy, and cirrus-affected pixels in a Sentinel-2 image using Cloud Score+ algorithm
         :::
 
-    -   The system applies scaling to the optical reflectance bands to convert the raw digital numbers (DNs) into physically meaningful surface reflectance values. A scale factor 0.0000275 and offset -0.2 are applied, as defined in the Landsat Collection 2 Surface Reflectance metadata. This conversion standardize the reflectance values to a range of approximately 0 to 1, enabling accurate comparison and analysis across different scenes and sensors.
+    -   For Landsat imagery, value scaling is implemented to convert the raw digital numbers (DNs) into physically meaningful surface reflectance values. A scale factor 0.0000275 and offset -0.2 are applied, as defined in the Landsat Collection 2 Surface Reflectance metadata. This conversion standardize the reflectance values to a range of approximately 0 to 1, enabling accurate comparison and analysis across different scenes and sensors.
 
         ::: callout-tip
         ## Related Functions
@@ -282,7 +284,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
         `data_acquisition.Reflectance_Data.rename_s2_bands()`: Rename Sentinel 2 SR bands to standardized semantic names (i.e B5 to RED_EDGE1)
         :::
 
-3.  The system then use the same parameter as multi-spectral data and use it to search collection 2 TOA data, except for Landsat 1-3 MSS. The TOA data thermal band (namely, band 10) is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
+3.  The system then use the same parameter in `optical_data` and use it to search collection 2 TOA data and (except for Landsat 1-3) select the thermal band. The selected thermal band is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
 
     ::: callout-tip
     ## Related Functions
@@ -292,16 +294,26 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     `data_acquisition.Reflectance_Data.get_thermal_bands():` to retrieve thermal band from Landsat collection 2 TOA data
     :::
 
-4.  The system evaluates whether the retrieved imagery meets the required spatial resolution, input year, and cloud cover thresholds. If suitable images are found, the system generates a composite by calculating the median value across the selected imagery, as implemented using the `median()` function from Earth Engine. The system also then clips and mosaics the satellite imagery.
+### Sentinel-2 Spatial Resolution Harmonization
 
-### Sentinel-2 Image Fusion
+Sentinel-2 bands have three spatial resolution: 10 m (Blue, Green, Red, NIR), 20 m (Red Edge 1, Red Edge 2, Red Edge, 3, Red Edge 4, SWIR 1, SWIR 2), and 60 m (Aerosol, Water vapor). For the final imagery reported to the user, the 60 m bands will be dropped from the composite, since it did not contain valuable information for classification task. To utilize the spectral richness of sentinel 2 imagery, image sharpening is implemented, transforming the 20 m bands to 10 m. Since Earth Engine did not have built-in pan-sharpening algorithm, High Pass Filter (HPF) approach is used to sharpen the 20 m bands.
 
-Sentinel-2 bands have three spatial resolution: 10 m (Blue, Green, Red, NIR), 20 m (Red Edge 1, Red Edge 2, Red Edge, 3, Red Edge 4, SWIR 1, SWIR 2), and 60 m (Aerosol, Water vapor). For the final imagery reported to the user, the 60 m bands will not be dropped since it did not fully contribute for the classification. To utilize the spectral richness of sentinel 2 imagery, image downscaling is implemented, transforming the 20 m bands to 10 m. Since Earth Engine did not have built-in pan sharpening algorithm, High Pass Filter (HPF) approach is used to sharpen the 20 m bands.
-
-HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MRA). HPF extract high frequency information from higher resolution image and inject them to lower resolution multi-spectral images by specified weights. This approach is chosen since some studies that HPF produce more accurate sharpened image ([Du et al, 2016](https://doi.org/10.3390/rs8040354); [Zheng et al, 2017](https://doi.org/10.3390/rs9121274)). Since Sentinel 2 did not panchromatic band, the average value of visible and near infrared bands can be used a substitute for panchromatic band in pan-sharpening approach [(Kaplan, 2019)](https://doi.org/10.3390/ecrs-2-05158)
+HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MRA) framework. HPF extract high frequency information from higher resolution image and inject them to lower resolution multi-spectral images by specified weights. This approach is chosen since some studies that HPF produce more accurate sharpened image ([Du et al, 2016](https://doi.org/10.3390/rs8040354); [Zheng et al, 2017](https://doi.org/10.3390/rs9121274)). Since Sentinel 2 did not panchromatic band, the average value of visible and near infrared bands can be used a substitute for panchromatic band in pan-sharpening approach [(Kaplan, 2019)](https://doi.org/10.3390/ecrs-2-05158)
 
 ::: callout-tip
-## Related Function
+## Related Functions
+
+`data_acquisition.Reflectance_data.mock_pan_band():` Create a mock panchromatic band from average value of visible and near infrared bands. The mock panchromatic band is used as input for high-pass filter sharpening approach
+
+`data_acquisition.Reflectance_data.sharpen_s2_bands():` Perform image sharpening for the 20m Sentinel-2 bands, resulting in 10 m bands. This function utilize high-pass filter algorithm with panchromatic band created using `mock_pan_band()`
+
+`data_acquisition.Reflectance_data.resample_s2_band():` Alternative approach for sentinel-2 band spatial resolution normalization. This approach only change the pixel size, without improving the spatial resolution of the 20 m bands.
+:::
+
+::: callout-caution
+## Feature Note
+
+The approach as well as the procedure used to perform spatial harmonization is not shown to the user. The user only receive the harmonize imagery and note regarding the approach used
 :::
 
 ## Mosaic and Composite for Satellite Imagery

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -247,17 +247,19 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a masked, scaled, and renamed image collection.
 
-    `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the
+    `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the `mask_s2_clouds`, `apply_s2_scale_factors`, and `rename_s2_bands` to return a standardize and ready to use image collection
     :::
 
     -   The system performs cloud masking using the quality assurance band (QA_PIXEL) QA_PIXEL band that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
 
-    -   Cloud masking for Sentinel-2 data use Cloud Score+ methods which implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e)
+    -   Cloud masking for Sentinel-2 data use Cloud Score+ methods which implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e).
 
         ::: callout-tip
         ## Related Functions
 
         `data_acquisition.Reflectance_Data.mask_landsat_sr()`: Mask clouds, shadows and cirrus for Landsat Collection 2 SR using QA_PIXEL band with confidence threshold
+
+        `data_acquisition.Reflectance_Data.mask_s2_clouds()`: Mask cloudy, hazy, and cirrus-affected pixels in a Sentinel-2 image using Cloud Score+ algorithm
         :::
 
     -   The system applies scaling to the optical reflectance bands to convert the raw digital numbers (DNs) into physically meaningful surface reflectance values. A scale factor 0.0000275 and offset -0.2 are applied, as defined in the Landsat Collection 2 Surface Reflectance metadata. This conversion standardize the reflectance values to a range of approximately 0 to 1, enabling accurate comparison and analysis across different scenes and sensors.
@@ -277,7 +279,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
         `data_acquisition.Reflectance_Data.rename_landsat_bands()`: to standardize Landsat Surface Reflectance (SR) band names based on sensor type. From 'SR_B*' or 'B*' to 'NIR', 'GREEN', etc.
 
-        `data_acquisition.Reflectance_Data.rename_s2_bands()`: Rename Sentinel 2 SR bands to standardized semantic names (i.e B5 to RED_EDGE1\_
+        `data_acquisition.Reflectance_Data.rename_s2_bands()`: Rename Sentinel 2 SR bands to standardized semantic names (i.e B5 to RED_EDGE1)
         :::
 
 3.  The system then use the same parameter as multi-spectral data and use it to search collection 2 TOA data, except for Landsat 1-3 MSS. The TOA data thermal band (namely, band 10) is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
@@ -297,6 +299,10 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 Sentinel-2 bands have three spatial resolution: 10 m (Blue, Green, Red, NIR), 20 m (Red Edge 1, Red Edge 2, Red Edge, 3, Red Edge 4, SWIR 1, SWIR 2), and 60 m (Aerosol, Water vapor). For the final imagery reported to the user, the 60 m bands will not be dropped since it did not fully contribute for the classification. To utilize the spectral richness of sentinel 2 imagery, image downscaling is implemented, transforming the 20 m bands to 10 m. Since Earth Engine did not have built-in pan sharpening algorithm, High Pass Filter (HPF) approach is used to sharpen the 20 m bands.
 
 HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MRA). HPF extract high frequency information from higher resolution image and inject them to lower resolution multi-spectral images by specified weights. This approach is chosen since some studies that HPF produce more accurate sharpened image ([Du et al, 2016](https://doi.org/10.3390/rs8040354); [Zheng et al, 2017](https://doi.org/10.3390/rs9121274)). Since Sentinel 2 did not panchromatic band, the average value of visible and near infrared bands can be used a substitute for panchromatic band in pan-sharpening approach [(Kaplan, 2019)](https://doi.org/10.3390/ecrs-2-05158)
+
+::: callout-tip
+## Related Function
+:::
 
 ## Mosaic and Composite for Satellite Imagery
 
@@ -430,6 +436,6 @@ This is a part of **System Response 1.3: Download Satellite Imagery and Continue
     `data_acquisition.build_custom_vis_param()`: function to allow the user to build their own band combinations
     :::
 
-4.  For details on exporting to Google Cloud Storage, Google Drive, and direct download, refer to helper modules
+4.  For details on exporting to Google Cloud Storage, Google Drive, and direct download, refer to helper module
 
 5.  The system saved the satellite imagery as an object to be loaded in the next modules.

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -2,7 +2,7 @@
 
 # Module Overview {.unnumbered}
 
-The output of this module is near–cloud-free satellite imagery that corresponds to the user-defined area of interest, which is essential for generating accurate and reliable land use and land cover (LULC) datasets. This module emphasizes the generation of pre-processed and corrected satellite imagery, incorporating procedures such as cloud masking and shadow removal.
+The output of this module is near–cloud-free satellite imagery that corresponds to the user-defined area of interest, which is essential for generating accurate and reliable land use and land cover (LULC) datasets. This module emphasizes the generation of pre-processed and corrected satellite imagery, incorporating procedures such as cloud masking, band and value standardization, as well as compositing.
 
 # Input {.unnumbered}
 
@@ -249,7 +249,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a standardize and ready to use image collection
 
-    `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the `mask_s2_clouds`, `apply_s2_scale_factors`, and `rename_s2_bands` to return a standardize and ready to use image collection
+    `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the `mask_s2_clouds`, and `rename_s2_bands` to return a standardize and ready to use image collection
     :::
 
     -   For Landsat imagery, cloud masking is applied using the quality assurance band (QA_PIXEL) that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
@@ -270,8 +270,6 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
         ## Related Functions
 
         `data_acquisition.Reflectance_Data.apply_scale_factors()`: to apply Landsat collection 2 scaling factors using the following formula: Digital Number (DN) \* scale_factor + offset. The scale factor will only be applied to optical bands.
-
-        `data_acquisition.Reflectance_Data.apply_s2_scale_factors():` Scaled Sentinel-2 surface reflectance values by multiplying the optical bands by 0.0001
         :::
 
     -   The spectral band is standardized according to the semantic names of the band itself. The common naming convention shared across the luma-ge pipeline, enabling downstream modules to reference bands by semantic name rather than sensor specific identifiers.
@@ -303,9 +301,7 @@ HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MR
 ::: callout-tip
 ## Related Functions
 
-`data_acquisition.Reflectance_data.mock_pan_band():` Create a mock panchromatic band from average value of visible and near infrared bands. The mock panchromatic band is used as input for high-pass filter sharpening approach
-
-`data_acquisition.Reflectance_data.sharpen_s2_bands():` Perform image sharpening for the 20m Sentinel-2 bands, resulting in 10 m bands. This function utilize high-pass filter algorithm with panchromatic band created using `mock_pan_band()`
+`data_acquisition.Reflectance_data.sharpen_s2_bands():` Perform image sharpening for the 20m Sentinel-2 bands using high pass filter (HPF). HPF sharpening consist of three main steps: (1) build pseudo-panchromatic bands from the average value of VIS-NIR band. (2) Applied Laplacian HPF kernel, perform bilinear resampling, and inject spectral reflectance detail. (3) Stack the sharpen image with VIS-NIR band
 
 `data_acquisition.Reflectance_data.resample_s2_band():` Alternative approach for sentinel-2 band spatial resolution normalization. This approach only change the pixel size, without improving the spatial resolution of the 20 m bands.
 :::

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -241,7 +241,15 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     -   Landsat 9 Operational Land Imager-2/OLI-2 (2021 - present)
     -   Sentinel 2A/B Multispectral Instrument/MSI (2015 - present)
 
-2.  The system retrieves images that match user’s selected criteria, including spatial resolution, target year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
+    ::: callout-note
+    **Feature Warning**
+
+    Sentinel-2 Level 2A only extends back to march 2017, since the European Space Agency (ESA) did not systematically generate Level 2A product unil then. Furthermore, the sentinel-2 atmospheric processor (Sen2cor) was release in late 2016.
+    :::
+
+2.  To address the limited coverage of Sentinel-2 in 2015-2017, Luma automatically select the Level 1C ToA reflectance data if the user select those years. Atmospheric correction of this data is not applied due to complexity of sentinel-2 pre-processing pipeline. Atmospheric correction for this data will be applied in the upcoming update.
+
+3.  The system retrieves images that match user’s selected criteria, including spatial resolution, target year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
 
     ::: callout-tip
     ## Related Functions
@@ -255,7 +263,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     -   For Landsat imagery, cloud masking is applied using the quality assurance band (QA_PIXEL) that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
 
-    -   For Sentinel-2 imagery, cloud masking is implemented using Cloud Score+ quality assessment processor. This approach use weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. This masking approach is conducted using link collection function in GEE, since Cloud Score+ collection have the same id and `system:index` properties as the individual Sentinel-2 image collection. Cloud Score+ produce more accurate cloud masking compared to other cloud masking approach such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e)
+    -   For Sentinel-2 imagery, cloud masking is implemented using Cloud Score+ quality assessment processor. This approach use weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. This masking approach is conducted using link collection function in GEE, since Cloud Score+ collection have the same id and `system:index` properties as the individual Sentinel-2 image collection. Cloud Score+ produce more accurate cloud masking compared to other cloud masking approach such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella 2023](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e)
 
         ::: callout-tip
         ## Related Functions
@@ -283,7 +291,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
         `data_acquisition.Reflectance_Data.rename_s2_bands()`: Rename Sentinel 2 SR bands to standardized semantic names (i.e B5 to RED_EDGE1)
         :::
 
-3.  The system then use the same parameter in `optical_data` and use it to search collection 2 TOA data and (except for Landsat 1-3) select the thermal band. The selected thermal band is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
+4.  The system then use the same parameter in `optical_data` and use it to search collection 2 TOA data and (except for Landsat 1-3) select the thermal band. The selected thermal band is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
 
     ::: callout-tip
     ## Related Functions

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -169,7 +169,7 @@ This is a part of **System Response 1.1: Area of Interest Definition**
 
 -   Primary method: using `geemap.gdf_to_ee()`
 
--   If primary method fails, proceed to secondary method: manual GeoJSON conversion by union multiple geometries first (`gpd.GeoDataFrame([{'geometry': union_geom}], crs=gdf.crs)`) and convert it to GeoJSON (`gdf.to_json()`). **Only polygon and multipolygon geometry type is supported in this method**.
+-   If primary method fails, proceed to secondary method: manual GeoJSON conversion by union multiple geometries first (`gpd.GeoDataFrame([{'geometry': union_geom}], crs=gdf.crs)`) and convert it to GeoJSON (`gdf.to_json()`). **Only polygon and multi-polygon geometry type is supported in this method**.
 
 -   If both primary and secondary method fails, proceed to the last option: bounding box conversion to estimate the rectangular approximation of the AOI (`ee.Geometry.Rectangle([bounds[0], bounds[1], bounds[2], bounds[3]])`).
 :::
@@ -193,7 +193,7 @@ This is a part of **User Journey 1.2: Determining Satellite Imageries Parameters
         ::: callout-important
         ## Error Handling Notification
 
-        Since only Landsat data is utilized, the system provides an error notification if no Landsat sensor is available in the selected time range.
+        An error/warning notification is shown to the user if there's no satellite data for the selected time range
         :::
 
     -   Maximum cloud cover: Set a preferred cloud cover threshold, or use the default value of 30%.
@@ -223,10 +223,10 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     `data_acquisition.Reflectance_Data.OPTICAL_DATASETS` defines the properties of Landsat Surface Reflectance (SR) collections (Collection 2, Level-2) to be fetched for optical data processing. In this list, the metadata for reporting the data retrieval is also define. More satellite sensor can be define here
 
-    `data_acquisition.Reflectance_Data.THERMAL_DATASETS` Define the properties of Landsat Top-of-Atmosphere (TOA) thermal bands. Since some landsat mission have different band names designation, the thermal band is refer in the list
+    `data_acquisition.Reflectance_Data.THERMAL_DATASETS` Define the properties of Landsat Top-of-Atmosphere (TOA) thermal bands. Since some Landsat mission have different band names designation, the thermal band is refer in the list
     :::
 
-    The system currently supports Landsat 1-3 RAW collection and and Landsat 4-9 surface reflectance (SR) collection. Additionally, Landsat 4 - 9 Top-of-Atmosphere (TOA) is used for retrieving thermal band as additional input band for the classification. This consideration stems from Landsat SR collection thermal band quality which often resulted in no data and prone to over-correction in high contrast land cover feature. Landsat mission availability is as follows:
+    The system currently supports Landsat 1-3 RAW collection and and Landsat 4-9 surface reflectance (SR) collection, and Sentinel 2 Multispectral Instrument (MSI) Leve 2A Harmonized Collection. Additionally, Landsat 4 - 9 Top-of-Atmosphere (TOA) is used for retrieving thermal band as additional input band for the classification. This consideration stems from Landsat SR collection thermal band quality which often resulted in no data and prone to over-correction in high contrast land cover feature. Landsat mission availability is as follows:
 
     -   Landsat 1 Multispectral Scanner/MSS (1972 - 1978)
     -   Landsat 2 Multispectral Scanner/MSS (1978 - 1982)
@@ -236,6 +236,7 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
     -   Landsat 7 Enhanced Thematic Mapper Plus/ETM+ (1999 - 2021)
     -   Landsat 8 Operational Land Imager/OLI (2013 - present)
     -   Landsat 9 Operational Land Imager-2/OLI-2 (2021 - present)
+    -   Sentinel 2A/B Multispectral Instrument/MSI (2015 - present)
 
 2.  The system retrieves images that match user’s selected criteria, including spatial resolution, year, and cloud cover based on the following input parameters: AOI, target map date, and cloud cover threshold.
 
@@ -244,15 +245,19 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
     `data_acqusition.parse_date_input():` Parse date input to YYYY-MM-DD format. Accepts either a year (int or 4-digit string) or a full date string. For year inputs, returns Jan 1 for start dates or Dec 31 for end dates. This function is used by `get_optical_data` and `get_thermal_bands`
 
-    `data_acquisition.Reflactance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a masked, scaled, and renamed image collection.
+    `data_acquisition.Reflectance_Data.get_optical_data():` to retrieve and the Landsat image collection based on the input parameters. This function uses the `mask_landsat_sr`, `apply_scale_factors`, and `rename_landsat_bands` to return a masked, scaled, and renamed image collection.
+
+    `data_acquisition.Reflectance_Data.get_s2_optical_data():` Retrieve Sentinel 2 image collection based on input parameters provided. This function uses the
     :::
 
     -   The system performs cloud masking using the quality assurance band (QA_PIXEL) QA_PIXEL band that encodes pixel conditions as bitwise flags using specific bit flags. Deterministic bit tests are applied to identify and exclude pixels affected by cirrus, clouds and cloud shadows. The bit value is adjusted based on the Landsat sensor selected by the user. Landsat 8-9 QA_PIXEL stored per-pixel confidence levels for clouds cirrus, and clouds shadow. These confidence values (ranging from 0–3) are extracted and filtered using hard-coded thresholds, such that pixels with medium to high confidence are masked out. Other Landsat sensor did not have confidence bit, therefore, only deterministic bit are used for cloud masking
 
+    -   Cloud masking for Sentinel-2 data use Cloud Score+ methods which implement weakly deep learning approach to grade the quality of individual image pixels and assign per-pixel quality assessment scores. Cloud Score+ resulted in cleaner imagery when compared with other cloud masking methods, such as s2cloudless and QA60. Methodological description of Cloud Score+ can be found in [Pasquarella (2023)](https://medium.com/google-earth/all-clear-with-cloud-score-bd6ee2e2235e)
+
         ::: callout-tip
         ## Related Functions
 
-        `data_acquisition.Reflactance_Data.mask_landsat_sr()`: Mask clouds, shadows and cirrus for Landsat Collection 2 SR using QA_PIXEL band with confidence threshold
+        `data_acquisition.Reflectance_Data.mask_landsat_sr()`: Mask clouds, shadows and cirrus for Landsat Collection 2 SR using QA_PIXEL band with confidence threshold
         :::
 
     -   The system applies scaling to the optical reflectance bands to convert the raw digital numbers (DNs) into physically meaningful surface reflectance values. A scale factor 0.0000275 and offset -0.2 are applied, as defined in the Landsat Collection 2 Surface Reflectance metadata. This conversion standardize the reflectance values to a range of approximately 0 to 1, enabling accurate comparison and analysis across different scenes and sensors.
@@ -260,28 +265,38 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
         ::: callout-tip
         ## Related Functions
 
-        `data_acquisition.Reflactance_Data.apply_scale_factors()`: to apply Landsat collection 2 scaling factors using the following formula: Digital Number (DN) \* scale_factor + offset. The scale factor will only be applied to optical bands.
+        `data_acquisition.Reflectance_Data.apply_scale_factors()`: to apply Landsat collection 2 scaling factors using the following formula: Digital Number (DN) \* scale_factor + offset. The scale factor will only be applied to optical bands.
+
+        `data_acquisition.Reflectance_Data.apply_s2_scale_factors():` Scaled Sentinel-2 surface reflectance values by multiplying the optical bands by 0.0001
         :::
 
-    -   The system renames the bands accordingly with the sensor type input.
+    -   The spectral band is standardized according to the semantic names of the band itself. The common naming convention shared across the luma-ge pipeline, enabling downstream modules to reference bands by semantic name rather than sensor specific identifiers.
 
         ::: callout-tip
         ## Related Functions
 
-        `data_acquisition.Reflactance_Data.rename_landsat_bands()`: to standardize Landsat Surface Reflectance (SR) band names based on sensor type. From 'SR_B*' or 'B*' to 'NIR', 'GREEN', etc.
+        `data_acquisition.Reflectance_Data.rename_landsat_bands()`: to standardize Landsat Surface Reflectance (SR) band names based on sensor type. From 'SR_B*' or 'B*' to 'NIR', 'GREEN', etc.
+
+        `data_acquisition.Reflectance_Data.rename_s2_bands()`: Rename Sentinel 2 SR bands to standardized semantic names (i.e B5 to RED_EDGE1\_
         :::
 
-3.  The system then use the same parameter as multispectral data and use it to search collection 2 TOA data, except for Landsat 1-3 MSS. The TOA data thermal band (namely, band 10) is then stacked with multispectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
+3.  The system then use the same parameter as multi-spectral data and use it to search collection 2 TOA data, except for Landsat 1-3 MSS. The TOA data thermal band (namely, band 10) is then stacked with multi-spectral band from SR data. Since band 11, contain larger calibration uncertainty, only band 10 is used. No additional pre-processing is conducted for thermal band since digital number value alone is considered satisfactory for discriminating land cover features.
 
     ::: callout-tip
     ## Related Functions
 
-    `data_acquisition.Reflectance_Data.has_thermal_capability():` Function to check if the landsat mission selected contain thermal bands
+    `data_acquisition.Reflectance_Data.has_thermal_capability():` Function to check if the Landsat mission selected contain thermal bands
 
-    `data_acquisition.Reflactance_Data.get_thermal_bands():` to retrieve thermal band from landsat collection 2 TOA data
+    `data_acquisition.Reflectance_Data.get_thermal_bands():` to retrieve thermal band from Landsat collection 2 TOA data
     :::
 
 4.  The system evaluates whether the retrieved imagery meets the required spatial resolution, input year, and cloud cover thresholds. If suitable images are found, the system generates a composite by calculating the median value across the selected imagery, as implemented using the `median()` function from Earth Engine. The system also then clips and mosaics the satellite imagery.
+
+### Sentinel-2 Image Fusion
+
+Sentinel-2 bands have three spatial resolution: 10 m (Blue, Green, Red, NIR), 20 m (Red Edge 1, Red Edge 2, Red Edge, 3, Red Edge 4, SWIR 1, SWIR 2), and 60 m (Aerosol, Water vapor). For the final imagery reported to the user, the 60 m bands will not be dropped since it did not fully contribute for the classification. To utilize the spectral richness of sentinel 2 imagery, image downscaling is implemented, transforming the 20 m bands to 10 m. Since Earth Engine did not have built-in pan sharpening algorithm, High Pass Filter (HPF) approach is used to sharpen the 20 m bands.
+
+HPF is traditional image fusion algorithm based on Multi-Resolution Analysis (MRA). HPF extract high frequency information from higher resolution image and inject them to lower resolution multi-spectral images by specified weights. This approach is chosen since some studies that HPF produce more accurate sharpened image ([Du et al, 2016](https://doi.org/10.3390/rs8040354); [Zheng et al, 2017](https://doi.org/10.3390/rs9121274)). Since Sentinel 2 did not panchromatic band, the average value of visible and near infrared bands can be used a substitute for panchromatic band in pan-sharpening approach [(Kaplan, 2019)](https://doi.org/10.3390/ecrs-2-05158)
 
 ## Mosaic and Composite for Satellite Imagery
 
@@ -384,7 +399,7 @@ This is a part of **System Response 1.3: Download Satellite Imagery and Continue
     ::: callout-tip
     ## Related Functions
 
-    `data_acquisition.Reflactance_Stats.get_collection_statistics():` to get comprehensive statistics about the gathered image collection.
+    `data_acquisition.Reflectance_Stats.get_collection_statistics():` to get comprehensive statistics about the gathered image collection.
     :::
 
 2.  The system provide a preset of commonly used band combinations as well as optimal value range for the imagery. The commonly used composites define in Luma-GE are:
@@ -415,6 +430,6 @@ This is a part of **System Response 1.3: Download Satellite Imagery and Continue
     `data_acquisition.build_custom_vis_param()`: function to allow the user to build their own band combinations
     :::
 
-4.  For details on exporting to Google Cloud Storage, refer to Earth Engine Initialization and Authentication page.
+4.  For details on exporting to Google Cloud Storage, Google Drive, and direct download, refer to helper modules
 
 5.  The system saved the satellite imagery as an object to be loaded in the next modules.


### PR DESCRIPTION
## Background
Higher resolution imagery is one of the most requested feature by various stakeholder during community engagement activities. One of this imagery is Sentinel-2 which feature highest spatial resolution of 10 m. The primary focus of these updates is to extend the module's functionality to support Sentinel-2 satellite imagery alongside existing Landsat imagery collection.
## Major Changes
### 1. **Expanded Spatial Resolution Support**
- **Before**: Spatial resolution was set to default 30 meters, since only landsat imager is supported
- **After**: Three spatial resolutions are now supported:
  - **10x10m**: Sentinel-2 only (temporal coverage: 2017-present)
  - **30x30m**: Landsat imagery collection (temporal coverage: 1972-present)
  - **100x100m**: RESTORE+ dataset using Landsat (thematic details at 100x100m)
 ### 2. **Sentinel-2 Data Collection Support**
**New Functions Added**:
- `data_acquisition.Reflectance_Data.S2_DATASETS`: Class-level dictionary for Sentinel-2 Level 2A Surface Reflectance collection
- `data_acquisition.Reflectance_Data.get_s2_optical_data()`: Retrieves Sentinel-2 image collection with preprocessing

**Supported Collections**:
- Added: Sentinel-2A/B Multispectral Instrument/MSI (2015 - present)

**Updated Collections Registry**:
- Improved documentation of `OPTICAL_DATASETS` dictionary structure
- Clarified metadata fields: `collection`, `cloud_property`, `type`, `sensor`, and `description`
### 3. **Sentinel-2 Cloud Masking Method**
**New Approach**:
- **Method**: Cloud Score+ algorithm
- **Description**: Implements a weakly supervised deep learning approach to grade pixel quality
- **Advantages**: Produces cleaner imagery compared to s2cloudless and QA60 methods
### 4. **Sentinel-2 Spatial Resolution Harmonization (NEW SECTION)**
**Overview**: Addresses Sentinel-2's multi-resolution band structure:
- 10m resolution: Blue, Green, Red, NIR
- 20m resolution: Red Edge 1-4, SWIR 1-2
- 60m resolution: Aerosol, Water vapor

**Proposed Approach**: High Pass Filter (HPF) Image Sharpening
- Transforms 20m bands to 10m resolution
- Removes 60m bands (did not provide relevant information for classification and too coarse to be sharpen)
- Uses mock panchromatic band created from visible and NIR band average

**Alternative**: Imagery resample and repojection

- Only change pixel size from 20 m to 10 m, without preserving spectral information.

### 5. **Sentinel-2 Spatial Resolution Harmonization**
**New Function**:
- `data_acquisition.Reflectance_Data.sharpen_s2_bands()`: Scales Sentinel-2 surface reflectance values by multiplying optical bands by 0.0001

### 6. **Sentinel-2 Band Naming Standardization**
**New Function**:
- `data_acquisition.Reflectance_Data.rename_s2_bands()`: Converts Sentinel-2 bands (e.g., B5) to standardized semantic names (e.g., RED_EDGE1)

## Minor Changes and Document Improvement

- Typo and spelling correction
- Enhanced description of `OPTICAL_DATASETS` to specify it's a "central registry"
- Clarified `THERMAL_DATASETS` purpose and structure
- Improved explanation of "standardized semantic names" concept
- Separated Landsat and Sentinel-2 cloud masking explanations with distinct bullet points