### PR TITLE
New Feature: Topographic Correction

### DIFF
--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -291,6 +291,16 @@ Since Sentinel-2 is already topographically corrected, this option is available 
 
 The SCS method consist of two primary steps, namely illumination condition and illumination correction. The illumination condition (IC) determine the pixel brightness given its slope and orientation. The illumination correction is applied for each spectral band with empirically derived c-value by running a linear regression between reflectance value and IC. However, this correction is applied selectively, according to a mask to only work on pixels in which corrections is meaningful ([Poortinga et. al. 2019](https://doi.org/10.3390/rs11070831)).
 
+::: callout-note
+## Related Function
+
+`data_acquisition.additional_correction.illumination_condition():` Compute the illumination condition (IC) for a single image and append it as an additional band along with cosZ, cosS, and slope.
+
+`data_acquisition.additional_correction.illumination_correction():` Perform illumination correction by fitting a linear model between IC and the given band over masked pixels, derive the empirical c-value, and apply the SCSc correction formula.
+
+`data_acquisition.additional_correction.apply_topo_corr():` Single function wrapper that executes both IC and illumination correction.
+:::
+
 ## Mosaic and Composite for Satellite Imagery
 
 **Luma Geospatial Engine**

--- a/01_data_acquisition.qmd
+++ b/01_data_acquisition.qmd
@@ -283,6 +283,14 @@ This is a part of **System Response 1.2: Search and Filter Imagery**
 
 4.  The system evaluates whether the retrieved imagery meets the required spatial resolution, input year, and cloud cover thresholds. If suitable images are found, the system generates a composite by calculating the median value across the selected imagery, as implemented using the `median()` function from Earth Engine. The system also then clips and mosaics the satellite imagery.
 
+### Topographic Correction
+
+Topographic correction are additional pre-processing for satellite imagery to mitigate the influence of rugged terrain on surface reflectance data. This pre-processing approach is crucial if there's variation in surface reflectance values between pixels with similar land cover and biophysical-structural properties.
+
+Since Sentinel-2 is already topographically corrected, this option is available for Landsat collections only. Luma-GE applied the a pixel-wise Sun-Canopy-Sensor with a c-correction (SCSc) proposed by [Soenen et. al. (2005)](https://doi.org/10.1109/TGRS.2005.852480). This approach use the sun-canopy-sensor (SCS) with a semi-empirical moderator (C) to account for diffuse radiation ([Poortinga et. al. 2019](https://doi.org/10.3390/rs11070831)). The ALOS 30m Global Surface Model version 4 is used for topographical base.
+
+The SCS method consist of two primary steps, namely illumination condition and illumination correction. The illumination condition (IC) determine the pixel brightness given its slope and orientation. The illumination correction is applied for each spectral band with empirically derived c-value by running a linear regression between reflectance value and IC. However, this correction is applied selectively, according to a mask to only work on pixels in which corrections is meaningful ([Poortinga et. al. 2019](https://doi.org/10.3390/rs11070831)).
+
 ## Mosaic and Composite for Satellite Imagery
 
 **Luma Geospatial Engine**


### PR DESCRIPTION
## Background
Differences in terrain orientation create variation in surface reflectance values between pixels with similar land cover and biophysical-structural properties. This difference can lead to relief shadows and multiple scattering effects. Topographic correction are additional pre-processing applied for satellite imagery to mitigate the influence of rugged terrain on surface reflectance data. Currently, topographic correction is not applied in the Luma-GE data acquisition pipeline. This pull request is propose to applied additional preprocessing, namely topographic correction to Landsat image collection in Luma-GE data acquisition pipeline. The correction will be optional and recommended to applied in area of interest with varying topography

## Changes
Add 'Topographic Correction' sub-section in Selection and Preparation of Satellite Imagery section. This contain a brief description of the modified sun-canopy-sensor correction that is adopted in Luma-GE

